### PR TITLE
internal/vanity: remove private repository support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
           key: "${{ runner.os }}-vanity-repos-v1"
       - name: "Build"
         env:
-          GITHUB_TOKEN: "${{ secrets.VANITY_GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ github.token }}"
           VANITY_REPO_CACHE_DIR: ".cache/vanity/repos"
           VANITY_CONCURRENCY: "4"
         run: |

--- a/internal/devtools/build/main.go
+++ b/internal/devtools/build/main.go
@@ -45,6 +45,7 @@ func (a *app) Run(ctx context.Context) error {
 		return vanity.Build(ctx, &vanity.Config{
 			Dir:          dir,
 			GitHubToken:  os.Getenv("GITHUB_TOKEN"),
+			GitHubOwner:  "astrophena",
 			ImportRoot:   "go.astrophena.name",
 			RepoCacheDir: os.Getenv("VANITY_REPO_CACHE_DIR"),
 			Concurrency:  envInt("VANITY_CONCURRENCY"),

--- a/internal/vanity/templates/index.html
+++ b/internal/vanity/templates/index.html
@@ -10,10 +10,8 @@ license that can be found in the LICENSE.md file.
   <p><a href="https://go.dev">Go</a> packages and tools that I wrote.</p>
   {{ range . }}
     {{ if not .Archived }}
-      {{ if not .Private }}
-        {{ if not .HasOnlyInternalPackages }}
-          {{ template "repo" . }}
-        {{ end }}
+      {{ if not .HasOnlyInternalPackages }}
+        {{ template "repo" . }}
       {{ end }}
     {{ end }}
   {{ end }}
@@ -21,10 +19,8 @@ license that can be found in the LICENSE.md file.
     <summary>No longer maintained</summary>
     {{ range . }}
       {{ if .Archived }}
-        {{ if not .Private }}
-          {{ if not .HasOnlyInternalPackages }}
-            {{ template "repo" . }}
-          {{ end }}
+        {{ if not .HasOnlyInternalPackages }}
+          {{ template "repo" . }}
         {{ end }}
       {{ end }}
     {{ end }}

--- a/internal/vanity/templates/pkg.html
+++ b/internal/vanity/templates/pkg.html
@@ -6,18 +6,7 @@ license that can be found in the LICENSE.md file.
 
 <!-- vim: set ft=gotplhtml: -->
 {{ define "pkg" }}
-  {{ if .Repo.Private }}
-    <h1>Whoa there!</h1>
-    <p>This module is private.</p>
-    <p>
-      To fetch it, ensure that your <code>GOPRIVATE</code> environment variable includes
-      <code>{{ .ImportPath }}</code> and you have access to <code>{{ .Repo.Name }}</code> repository.
-    </p>
-    <p>
-      See <a href="https://go.dev/ref/mod#private-module-privacy">Go documentation</a> for reference.
-    </p>
-    <p>If you got here by mistake, go to the <a href="https://astrophena.name">home page</a>.</p>
-  {{ else if .Repo.HasOnlyInternalPackages }}
+  {{ if .Repo.HasOnlyInternalPackages }}
     {{ template "repo" .Repo }}
     <p>This module does not contain any importable packages.</p>
   {{ else }}

--- a/internal/vanity/vanity.go
+++ b/internal/vanity/vanity.go
@@ -43,6 +43,8 @@ type Config struct {
 	Dir string
 	// GitHubToken is used to access the GitHub API.
 	GitHubToken string
+	// GitHubOwner is the GitHub user or organization whose public repositories are published.
+	GitHubOwner string
 	// ImportRoot is the root import path for the published packages.
 	ImportRoot string
 	// HTTPClient is used for GitHub API requests.
@@ -157,9 +159,9 @@ func Build(ctx context.Context, c *Config) error {
 
 	// Build pages for packages and repository roots.
 	for _, repo := range repos {
-		// Public repositories with only internal packages still get a root page
+		// Repositories with only internal packages still get a root page
 		// that explains there are no importable packages.
-		if repo.HasOnlyInternalPackages && !repo.Private {
+		if repo.HasOnlyInternalPackages {
 			repo.Pkgs = []*pkg{
 				{
 					ImportPath: c.ImportRoot + "/" + repo.Name,
@@ -170,12 +172,11 @@ func Build(ctx context.Context, c *Config) error {
 		}
 		for _, pkg := range repo.Pkgs {
 			if err := b.buildPage(filepath.Join(siteDir, "pages", pkg.BasePath+".html"), &site.Page{
-				Title:       pkg.ImportPath,
-				Template:    "main",
-				Type:        "page",
-				Permalink:   "/" + pkg.BasePath,
-				MetaTags:    metaTagsForRepo(c, repo),
-				ContentOnly: repo.Private,
+				Title:     pkg.ImportPath,
+				Template:  "main",
+				Type:      "page",
+				Permalink: "/" + pkg.BasePath,
+				MetaTags:  metaTagsForRepo(c, repo),
 			}, "pkg", pkg); err != nil {
 				return err
 			}
@@ -263,9 +264,9 @@ func (b *buildContext) buildPage(path string, page *site.Page, tmpl string, data
 
 type repo struct {
 	// Populated from the GitHub API.
-	Name          string `json:"name"`
-	URL           string `json:"url"`
-	Private       bool   `json:"private"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+
 	Description   string `json:"description"`
 	Archived      bool   `json:"archived"`
 	CloneURL      string `json:"clone_url"`
@@ -303,20 +304,26 @@ type pkg struct {
 }
 
 func makeRequest[Response any](ctx context.Context, c *Config, url string) (Response, error) {
+	headers := map[string]string{}
+	if c.GitHubToken != "" {
+		headers["Authorization"] = "Bearer " + c.GitHubToken
+	}
 	return request.Make[Response](ctx, request.Params{
-		Method: http.MethodGet,
-		URL:    url,
-		Headers: map[string]string{
-			"Authorization": "Bearer " + c.GitHubToken,
-		},
+		Method:     http.MethodGet,
+		URL:        url,
+		Headers:    headers,
 		HTTPClient: c.HTTPClient,
 	})
 }
 
 func listRepos(ctx context.Context, c *Config) ([]*repo, error) {
+	if c.GitHubOwner == "" {
+		return nil, errors.New("empty GitHub owner")
+	}
+
 	var repos []*repo
 	for page := 1; ; page++ {
-		u := fmt.Sprintf("https://api.github.com/user/repos?per_page=100&page=%d", page)
+		u := fmt.Sprintf("https://api.github.com/users/%s/repos?per_page=100&page=%d", url.PathEscape(c.GitHubOwner), page)
 		batch, err := makeRequest[[]*repo](ctx, c, u)
 		if err != nil {
 			return nil, err
@@ -343,16 +350,6 @@ func parallelism(c *Config) int {
 }
 
 func prepareRepo(ctx context.Context, c *Config, repo *repo, reposDir string) error {
-	if repo.Private {
-		// Private repositories get a synthetic root package page with access instructions.
-		repo.Pkgs = []*pkg{{
-			BasePath:   repo.Name,
-			ImportPath: c.ImportRoot + "/" + repo.Name,
-			Repo:       repo,
-		}}
-		return nil
-	}
-
 	if !strings.HasSuffix(repo.Description, ".") {
 		repo.Description += "."
 	}

--- a/internal/vanity/vanity_test.go
+++ b/internal/vanity/vanity_test.go
@@ -28,7 +28,6 @@ var repos = []repo{
 	{
 		Name:          "nogomod",
 		URL:           "https://api.github.com/repos/example/nogomod",
-		Private:       false,
 		Description:   "Not a Go module.",
 		Archived:      false,
 		CloneURL:      filepath.Join("internal", "vanity", "testdata", "nogomod.bundle"),
@@ -38,7 +37,6 @@ var repos = []repo{
 	{
 		Name:          "noroot",
 		URL:           "https://api.github.com/repos/example/noroot",
-		Private:       false,
 		Description:   "Doesn't have root package.",
 		Archived:      false,
 		CloneURL:      filepath.Join("internal", "vanity", "testdata", "noroot.bundle"),
@@ -48,7 +46,6 @@ var repos = []repo{
 	{
 		Name:          "nothing",
 		URL:           "https://api.github.com/repos/example/nothing",
-		Private:       false,
 		Description:   "Package nothing does nothing.",
 		Archived:      false,
 		CloneURL:      filepath.Join("internal", "vanity", "testdata", "nothing.bundle"),
@@ -58,7 +55,6 @@ var repos = []repo{
 	{
 		Name:          "base",
 		URL:           "https://api.github.com/repos/example/base",
-		Private:       false,
 		Description:   "Package base does base.",
 		Archived:      false,
 		CloneURL:      filepath.Join("internal", "vanity", "testdata", "base.bundle"),
@@ -68,7 +64,6 @@ var repos = []repo{
 	{
 		Name:          "internalonlyrepo",
 		URL:           "https://api.github.com/repos/example/internalonlyrepo",
-		Private:       false,
 		Description:   "Repo with only internal packages.",
 		Archived:      false,
 		CloneURL:      filepath.Join("internal", "vanity", "testdata", "internalonlyrepo.bundle"),
@@ -80,7 +75,6 @@ var repos = []repo{
 var secondPageRepo = repo{
 	Name:          "page2repo",
 	URL:           "https://api.github.com/repos/example/page2repo",
-	Private:       false,
 	Description:   "Repo returned on the second page.",
 	Archived:      false,
 	CloneURL:      filepath.Join("internal", "vanity", "testdata", "nothing.bundle"),
@@ -146,6 +140,7 @@ func TestBuild(t *testing.T) {
 	c := &Config{
 		Dir:         dir,
 		GitHubToken: githubToken,
+		GitHubOwner: "example",
 		ImportRoot:  "example.com",
 		HTTPClient:  testutil.MockHTTPClient(testHandler(t)),
 		Concurrency: 2,
@@ -192,6 +187,7 @@ func TestBuildWithRepoCacheDir(t *testing.T) {
 		c := &Config{
 			Dir:          dir,
 			GitHubToken:  githubToken,
+			GitHubOwner:  "example",
 			ImportRoot:   "example.com",
 			HTTPClient:   testutil.MockHTTPClient(testHandler(t)),
 			RepoCacheDir: cacheDir,
@@ -216,7 +212,8 @@ func wantFile(t *testing.T, path string) {
 
 func testHandler(t *testing.T) http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("api.github.com/user/repos", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("api.github.com/users/{owner}/repos", func(w http.ResponseWriter, r *http.Request) {
+		testutil.AssertEqual(t, r.PathValue("owner"), "example")
 		testutil.AssertEqual(t, strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "), githubToken)
 		respondJSON(t, w, repos)
 	})
@@ -272,6 +269,7 @@ func TestListReposPagination(t *testing.T) {
 
 	c := &Config{
 		GitHubToken: githubToken,
+		GitHubOwner: "example",
 		HTTPClient:  testutil.MockHTTPClient(handler),
 	}
 


### PR DESCRIPTION
List public repositories through the users/{owner}/repos API instead of the authenticated user/repos endpoint, and use the built-in GitHub Actions token for vanity builds.
